### PR TITLE
Add os.getloadavg()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Pythonic.swift
 
-Pythonic.swift is a Swift library implementating selected parts of Python's standard library and making them available to your Swift code.
+Pythonic.swift is a Swift library implementating selected parts of [Python's standard library](https://docs.python.org/2/library/) and making them available to your Swift code.
 
 ```import Pythonic``` allows you to write Python flavored code such as:
 

--- a/src/Pythonic.os.swift
+++ b/src/Pythonic.os.swift
@@ -190,6 +190,13 @@ public class os {
         return NSFileManager.defaultManager().currentDirectoryPath
     }
 
+    public class func getloadavg() -> (Double, Double, Double) {
+        var avg = [Double](count: 3, repeatedValue: 0)
+        Foundation.getloadavg(&avg, 3)
+
+        return (avg[0], avg[1], avg[2])
+    }
+
     public class func remove(path: String) {
         return os.unlink(path)
     }


### PR DESCRIPTION
Hi @practicalswift!

A few questions about this change.

1. I’m assuming that `OSError` is being ignored in Pythonic.swift (`os.getloadavg()` raises it on error in Python), as `os.remove()` isn’t _“implementing”_ it either (for example).
2. Not sure what test(s) could be added for this. 3 values returned and each `>= 0`? Could anything else be asserted about a load average value?

Let me know and I can make the changes accordingly to this PR.